### PR TITLE
PrivatBankApi

### DIFF
--- a/src/main/java/org/teamthree/banks/privatbank/Currency.java
+++ b/src/main/java/org/teamthree/banks/privatbank/Currency.java
@@ -1,0 +1,8 @@
+package org.teamthree.banks.privatbank;
+
+public enum Currency {
+    EUR,
+    USD,
+    PLZ,
+    UAH
+}

--- a/src/main/java/org/teamthree/banks/privatbank/CurrencyItem.java
+++ b/src/main/java/org/teamthree/banks/privatbank/CurrencyItem.java
@@ -1,0 +1,13 @@
+package org.teamthree.banks.privatbank;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class CurrencyItem {
+    private Currency ccy;
+    private Currency base_ccy;
+    private BigDecimal buy;
+    private BigDecimal sale;
+}

--- a/src/main/java/org/teamthree/banks/privatbank/CurrencyService.java
+++ b/src/main/java/org/teamthree/banks/privatbank/CurrencyService.java
@@ -1,0 +1,10 @@
+package org.teamthree.banks.privatbank;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public interface CurrencyService {
+    BigDecimal getPurchaseRate(Currency currency) throws IOException;
+
+    BigDecimal getSalesRate(Currency currency) throws IOException;
+}

--- a/src/main/java/org/teamthree/banks/privatbank/PrintCurrencyService.java
+++ b/src/main/java/org/teamthree/banks/privatbank/PrintCurrencyService.java
@@ -1,0 +1,36 @@
+package org.teamthree.banks.privatbank;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class PrintCurrencyService {
+    CurrencyService currencyService = new PrivatBankCurrencyService();
+    public BigDecimal salesRates(Currency currency) {
+        BigDecimal salesRate;
+        try {
+            salesRate = currencyService.getSalesRate(currency);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return salesRate;
+    }
+    public BigDecimal purchaseRates (Currency currency) {
+        BigDecimal purchaseRate;
+        try {
+            purchaseRate = currencyService.getPurchaseRate(currency);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return purchaseRate;
+    }
+    public String convert(BigDecimal salesRate, BigDecimal purchaseRate, Currency currency){
+        String templateOfMessage = "Purchase rate UAH => ${currency} = ${purchaseRate}\nSales rate ${currency} => UAH = ${salesRate}";
+        BigDecimal roundedRate = salesRate.setScale(2, RoundingMode.HALF_UP);
+        BigDecimal roundedRate2 = purchaseRate.setScale(2, RoundingMode.HALF_UP);
+        return templateOfMessage
+                .replace("${currency}", currency.name())
+                .replace("${salesRate}",roundedRate +"")
+                .replace("${purchaseRate}", roundedRate2 +"");
+    }
+}

--- a/src/main/java/org/teamthree/banks/privatbank/PrivatBankCurrencyService.java
+++ b/src/main/java/org/teamthree/banks/privatbank/PrivatBankCurrencyService.java
@@ -1,0 +1,94 @@
+package org.teamthree.banks.privatbank;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.jsoup.Jsoup;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrivatBankCurrencyService implements CurrencyService{
+    private final String url = "https://api.privatbank.ua/p24api/pubinfo?exchange&coursid=5";
+    private final String urlPLZ = "https://api.privatbank.ua/p24api/pubinfo?exchange&coursid=4";
+    @Override
+    public BigDecimal getPurchaseRate(Currency currency) throws IOException {
+        String response = Jsoup
+                .connect(urlPLZ)
+                .ignoreContentType(true)
+                .get()
+                .body()
+                .text();
+        String response1 = Jsoup
+                .connect(url)
+                .ignoreContentType(true)
+                .get()
+                .body()
+                .text();
+        Type typeToken = TypeToken
+                .getParameterized(List.class, CurrencyItem.class)
+                .getType();
+        Gson gson = new Gson();
+        List<CurrencyItem> currencyItems = gson.fromJson(response, typeToken);
+        Type listType = new TypeToken<List<CurrencyItem>>() {}.getType();
+        List<CurrencyItem> currencyItems2 = gson.fromJson(response1, listType);
+        currencyItems.addAll(currencyItems2);
+        List<CurrencyItem> filteredCurrencyItems = new ArrayList<>();
+        for (CurrencyItem currencyItem : currencyItems) {
+            if (currencyItem.getCcy() != null &&(currencyItem.getCcy().equals(Currency.USD) ||
+                    currencyItem.getCcy().equals(Currency.EUR) ||
+                    currencyItem.getCcy().equals(Currency.PLZ))) {
+                filteredCurrencyItems.add(currencyItem);
+            }
+        }
+
+        return filteredCurrencyItems
+                .stream()
+                .filter(it->it.getCcy().equals(currency))
+                .filter(it -> it.getBase_ccy().equals(Currency.UAH))
+                .map(CurrencyItem::getBuy)
+                .findFirst()
+                .orElseThrow();
+    }
+    @Override
+    public BigDecimal getSalesRate(Currency currency) throws IOException{
+        String response = Jsoup
+                .connect(urlPLZ)
+                .ignoreContentType(true)
+                .get()
+                .body()
+                .text();
+        String response1 = Jsoup
+                .connect(url)
+                .ignoreContentType(true)
+                .get()
+                .body()
+                .text();
+        Type typeToken = TypeToken
+                .getParameterized(List.class, CurrencyItem.class)
+                .getType();
+        Gson gson = new Gson();
+        List<CurrencyItem> currencyItems = gson.fromJson(response, typeToken);
+        Type listType = new TypeToken<List<CurrencyItem>>() {}.getType();
+        List<CurrencyItem> currencyItems2 = gson.fromJson(response1, listType);
+        currencyItems.addAll(currencyItems2);
+        List<CurrencyItem> filteredCurrencyItems = new ArrayList<>();
+        for (CurrencyItem currencyItem : currencyItems) {
+            if (currencyItem.getCcy() != null &&(currencyItem.getCcy().equals(Currency.USD) ||
+                    currencyItem.getCcy().equals(Currency.EUR) ||
+                    currencyItem.getCcy().equals(Currency.PLZ))) {
+                filteredCurrencyItems.add(currencyItem);
+            }
+        }
+
+        return filteredCurrencyItems
+                .stream()
+                .filter(it->it.getCcy().equals(currency))
+                .filter(it -> it.getBase_ccy().equals(Currency.UAH))
+                .map(CurrencyItem::getSale)
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
В даній гілці представлено реалізацію PrivatBank Api, за допомогою якої можна підтягнути курс валют євро, долара і злотого до гривні (курс купівлі і продажу в Приват Банку в реальному часі). Валюти були представлені в енамі Currency для їх подальшого використання. 
В класі  CurrencyItem було введено приватні поля, що містять змінні, що треба використати, їх назви відповідають назвам у json від PrivatBank Api. До цього класу застосовано бібліотеку Lombok (@Data) , що дозволяє створювати всі необхідні геттери і сеттери, не прописуючи їх багатослівно. 
Код містить інтерфейс CurrencyService, який має два методи для подальшого перевизначення (метод, що виводитиме курс упівлі і метод, що показуватиме курс продажу. 
Інтерфейс реалізовано в класі PrivatBankCurrencyService. В класі я використовувала 2 url, оскільки за одним  можна підтягнути тільки євро і долар, а за іншим злотий з переліку інших валют(окрім тих, що є в першому посиланні). В цьому класі я застосовувала Jsoup і json бібліотеки, щоб добути з Privat Bank Api необхідну інформацію, яку я зібрала в ArrayList і застосувала Stream до нього, щоб виділити тільки окремо курс купівлі і курс продажу в двох методах.
В класі PrintCurrencyService  я використала написані методи класу PrivatBankCurrencyServise для подальшого написання методу-обгортки (convert), що додасть візуальноговигляду виводу інформації про валюти. Прописано тут і округлення до двох знаків після коми(як за замовченням). До функціоналу телеграму буде підключатись і використовуватись PrivatBankCurrencyService і PrintCurrenceService, де є головний функціонал. 