### PR TITLE
Api Monobank realisation

### DIFF
--- a/src/main/java/org/teamthree/banks/monobank/Currency.java
+++ b/src/main/java/org/teamthree/banks/monobank/Currency.java
@@ -1,0 +1,8 @@
+package org.teamthree.banks.monobank;
+
+public enum Currency {
+        UAH,
+        USD,
+        EUR,
+        PLN;
+}

--- a/src/main/java/org/teamthree/banks/monobank/CurrencyItem.java
+++ b/src/main/java/org/teamthree/banks/monobank/CurrencyItem.java
@@ -1,0 +1,16 @@
+package org.teamthree.banks.monobank;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class CurrencyItem {
+
+    private Integer currencyCodeA;
+    private Integer currencyCodeB;
+    private BigDecimal rateBuy;
+    private BigDecimal rateSell;
+    private Currency original;
+    private Currency toConvert;
+}

--- a/src/main/java/org/teamthree/banks/monobank/CurrencyRateApiService.java
+++ b/src/main/java/org/teamthree/banks/monobank/CurrencyRateApiService.java
@@ -1,0 +1,13 @@
+package org.teamthree.banks.monobank;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface CurrencyRateApiService {
+
+    List<CurrencyItem> getRates();
+
+    BigDecimal rateBuy(List<CurrencyItem> currencyItems, Currency currency);
+
+    BigDecimal rateSell(List<CurrencyItem> currencyItems, Currency currency);
+}

--- a/src/main/java/org/teamthree/banks/monobank/MonobankCurrencyRateService.java
+++ b/src/main/java/org/teamthree/banks/monobank/MonobankCurrencyRateService.java
@@ -1,0 +1,88 @@
+package org.teamthree.banks.monobank;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.jsoup.Jsoup;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.teamthree.banks.monobank.Currency.*;
+
+public class MonobankCurrencyRateService implements CurrencyRateApiService {
+
+    String url = "https://api.monobank.ua/bank/currency";
+
+    public List<CurrencyItem> getRates() {
+
+        String response;
+        try {
+            response = Jsoup
+                    .connect(url)
+                    .ignoreContentType(true)
+                    .get()
+                    .body()
+                    .text();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return convertResponse(response);
+
+
+    }
+
+    @Override
+    public BigDecimal rateBuy(List<CurrencyItem> currencyItems, Currency currency) {
+
+        return currencyItems.stream()
+                .filter(item -> item.getOriginal() == currency)
+                .filter(item -> item.getToConvert() == UAH)
+                .map(CurrencyItem::getRateBuy)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Override
+    public BigDecimal rateSell(List<CurrencyItem> currencyItems, Currency currency) {
+        return currencyItems.stream()
+                .filter(item -> item.getOriginal() == currency)
+                .filter(item -> item.getToConvert() == UAH)
+                .map(CurrencyItem::getRateSell)
+                .findFirst()
+                .orElseThrow(ArithmeticException::new);
+
+    }
+
+    private List<CurrencyItem> convertResponse(String response) {
+        Type typeToken = TypeToken
+                .getParameterized(List.class, CurrencyItem.class)
+                .getType();
+        List<CurrencyItem> currencyItems = new Gson().fromJson(response, typeToken);
+
+        Map<Integer, Currency> currencyMap = Map.of(
+                980, UAH,
+                840, USD,
+                978, EUR,
+                985, PLN
+        );
+        return currencyItems.stream()
+                .peek(item -> {
+                    if (currencyMap.containsKey(item.getCurrencyCodeA())) {
+                        item.setOriginal(currencyMap.get(item.getCurrencyCodeA()));
+                    }
+                })
+                .peek(item -> {
+                    if (currencyMap.containsKey(item.getCurrencyCodeB())) {
+                        item.setToConvert(currencyMap.get(item.getCurrencyCodeB()));
+                    }
+                })
+                .filter(item -> item.getOriginal() != null)
+                .filter(item -> item.getToConvert() == UAH)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
В пекедже Monobank реализована работа с Api Monobank, с помощью которого мы вытягиваем курсы купле/прродажи валют Валюты записаны в Enum Currency
В классе CurrencyItem указаны переменные которые соответствуют названия json формата Monobank Api, так же добавлено 2 переменные Currency original, Currency toConvert для конвертации кода валюты в абревиатуру из Enum, в класс CurrencyItem  так же используется библиотека Lombok (@DaTa) для создания геттеров и сеттеров Интерфейс CurrencyRateApiService имеет 3 метода которые, метод getRates() сохраняет информацию из Api, метод rateBuy() возвращает курс покупки валюты и метод rateSell() возвращает курс продажи Класс MonobankCurrencyRateService имплементирует интерфейс CurrencyRateApiService и имплементирует его методы, для более удобной читабельности кода отдельно вынесен метод convertResponse() который считывает Api и возвращает List, в метод так же добавлена Map currencyMap для, добавлена она для чтобы в дальнейшем привести валюты из формата кода(980, 840, 978, 985) в формат аббревиатур из Enum, так же добавлены фильтры для сохранения данных только тех валют которые есть в Enum. Методы rateBuy и rateSell принимают данные List и Enum и возвращают курс покупки и продажи соответственно